### PR TITLE
Remove FileType property from Workspaces class

### DIFF
--- a/CodeNest.DAL/Models/Workspaces.cs
+++ b/CodeNest.DAL/Models/Workspaces.cs
@@ -22,7 +22,5 @@ namespace CodeNest.DAL.Models
         public ObjectId Id { get; set; }
         public string? Name { get; set; }
         public string? Description { get; set; }
-
-        public string? FileType { get; set; }
     }
 }

--- a/CodeNest.DAL/Repository/WorkSpaceRepository.cs
+++ b/CodeNest.DAL/Repository/WorkSpaceRepository.cs
@@ -43,7 +43,6 @@ namespace CodeNest.DAL.Repository
                     Description = workspacesDto.Description,
                     CreatedBy = user,
                     CreatedOn = DateTime.UtcNow
-
                 };
                 await _mongoDbService.WorkSpaces
                     .InsertOneAsync(workspaces);


### PR DESCRIPTION
The FileType property has been removed from the Workspaces class in the CodeNest.DAL.Models namespace. Consequently, the creation of a Workspaces object in the WorkSpaceRepository class within the CodeNest.DAL.Repository namespace has been updated to no longer include the FileType property. This change simplifies the Workspaces model by removing an unnecessary or redundant property.